### PR TITLE
Add a timeout to requests made by miniflux.Client

### DIFF
--- a/miniflux.py
+++ b/miniflux.py
@@ -38,10 +38,11 @@ class ClientError(Exception):
 class Client:
     API_VERSION = 1
 
-    def __init__(self, base_url, username, password):
+    def __init__(self, base_url, username, password, timeout=None):
         self._base_url = base_url
         self._username = username
         self._password = password
+        self._timeout = timeout
         self._auth = (self._username, self._password)
 
     def _get_endpoint(self, path):
@@ -72,7 +73,7 @@ class Client:
 
     def export(self):
         endpoint = self._get_endpoint('/export')
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.text
         raise ClientError(response)
@@ -80,28 +81,28 @@ class Client:
     def discover(self, website_url):
         endpoint = self._get_endpoint('/discover')
         data = {'url': website_url}
-        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
 
     def get_feeds(self):
         endpoint = self._get_endpoint('/feeds')
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
 
     def get_feed(self, feed_id):
         endpoint = self._get_endpoint('/feeds/{}'.format(feed_id))
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
 
     def get_feed_icon(self, feed_id):
         endpoint = self._get_endpoint('/feeds/{}/icon'.format(feed_id))
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
@@ -109,7 +110,7 @@ class Client:
     def create_feed(self, feed_url, category_id):
         endpoint = self._get_endpoint('/feeds')
         data = {'feed_url': feed_url, 'category_id': category_id}
-        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code == 201:
             return response.json()['feed_id']
         raise ClientError(response)
@@ -140,27 +141,27 @@ class Client:
         if category_id:
             data['category'] = {'id': category_id}
 
-        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code == 201:
             return response.json()
         raise ClientError(response)
 
     def refresh_feed(self, feed_id):
         endpoint = self._get_endpoint('/feeds/{}/refresh'.format(feed_id))
-        response = requests.put(endpoint, auth=self._auth)
+        response = requests.put(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code >= 400:
             raise ClientError(response)
         return True
 
     def delete_feed(self, feed_id):
         endpoint = self._get_endpoint('/feeds/{}'.format(feed_id))
-        response = requests.delete(endpoint, auth=self._auth)
+        response = requests.delete(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code != 204:
             raise ClientError(response)
 
     def get_feed_entry(self, feed_id, entry_id):
         endpoint = self._get_endpoint('/feeds/{}/entries/{}'.format(feed_id, entry_id))
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
@@ -168,14 +169,14 @@ class Client:
     def get_feed_entries(self, feed_id, status=None, offset=None, limit=None, order=None, direction=None):
         endpoint = self._get_endpoint('/feeds/{}/entries'.format(feed_id))
         params = self._get_params(status, offset, limit, order, direction)
-        response = requests.get(endpoint, auth=self._auth, params=params)
+        response = requests.get(endpoint, auth=self._auth, params=params, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
 
     def get_entry(self, entry_id):
         endpoint = self._get_endpoint('/entries/{}'.format(entry_id))
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
@@ -183,7 +184,7 @@ class Client:
     def get_entries(self, status=None, offset=None, limit=None, order=None, direction=None):
         endpoint = self._get_endpoint('/entries')
         params = self._get_params(status, offset, limit, order, direction)
-        response = requests.get(endpoint, auth=self._auth, params=params)
+        response = requests.get(endpoint, auth=self._auth, params=params, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
@@ -191,21 +192,21 @@ class Client:
     def update_entries(self, entry_ids, status):
         endpoint = self._get_endpoint('/entries')
         data = {'entry_ids': entry_ids, 'status': status}
-        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code >= 400:
             raise ClientError(response)
         return True
 
     def toggle_bookmark(self, entry_id):
         endpoint = self._get_endpoint('/entries/{}/bookmark'.format(entry_id))
-        response = requests.put(endpoint, auth=self._auth)
+        response = requests.put(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code >= 400:
             raise ClientError(response)
         return True
 
     def get_categories(self):
         endpoint = self._get_endpoint('/categories')
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
@@ -213,7 +214,7 @@ class Client:
     def create_category(self, title):
         endpoint = self._get_endpoint('/categories')
         data = {'title': title}
-        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code == 201:
             return response.json()
         raise ClientError(response)
@@ -221,20 +222,20 @@ class Client:
     def update_category(self, category_id, title):
         endpoint = self._get_endpoint('/categories/{}'.format(category_id))
         data = {'id': category_id, 'title': title}
-        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code == 201:
             return response.json()
         raise ClientError(response)
 
     def delete_category(self, category_id):
         endpoint = self._get_endpoint('/categories/{}'.format(category_id))
-        response = requests.delete(endpoint, auth=self._auth)
+        response = requests.delete(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code != 204:
             raise ClientError(response)
 
     def get_users(self):
         endpoint = self._get_endpoint('/users')
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
@@ -247,7 +248,7 @@ class Client:
 
     def _get_user(self, user_id_or_username):
         endpoint = self._get_endpoint('/users/{}'.format(user_id_or_username))
-        response = requests.get(endpoint, auth=self._auth)
+        response = requests.get(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code == 200:
             return response.json()
         raise ClientError(response)
@@ -255,7 +256,7 @@ class Client:
     def create_user(self, username, password, is_admin):
         endpoint = self._get_endpoint('/users')
         data = {'username': username, 'password': password, 'is_admin': is_admin}
-        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.post(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code == 201:
             return response.json()
         raise ClientError(response)
@@ -283,13 +284,13 @@ class Client:
         if entry_direction:
             data['entry_direction'] = entry_direction
 
-        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data))
+        response = requests.put(endpoint, auth=self._auth, data=json.dumps(data), timeout=self._timeout)
         if response.status_code == 201:
             return response.json()
         raise ClientError(response)
 
     def delete_user(self, user_id):
         endpoint = self._get_endpoint('/users/{}'.format(user_id))
-        response = requests.delete(endpoint, auth=self._auth)
+        response = requests.delete(endpoint, auth=self._auth, timeout=self._timeout)
         if response.status_code != 204:
             raise ClientError(response)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from distutils.core import setup
 
 setup(
     name='miniflux',
-    version='0.0.1',
+    version='0.0.2',
     install_requires=[
         'requests',
     ],


### PR DESCRIPTION
I've started to use miniflux-python in a GUI app I'm working on. Indefinite timeouts used by requests are a problem, requests to the server never timeout when there's a bad network.